### PR TITLE
Accept clicks on workspaces borders

### DIFF
--- a/sawfishpager.c
+++ b/sawfishpager.c
@@ -224,8 +224,12 @@ gint button_press_event( GtkWidget *widget, GdkEventButton *event, gpointer d )
   mouse_x = x = (int) event->x;
   mouse_y = y = (int) event->y;
 
-  if( !(x % ws_width) || !(y % ws_height) ) /* WS border */
-    return TRUE;
+  if( !(x % ws_width) || !(y % ws_height) ) { /* WS border */
+    if( x == width - 1 )
+      x--;
+    if( y == height - 1 )
+      y--;
+  }
 
   /* Button1 changes viewport */
   if( event->button == 1 ) {
@@ -263,8 +267,12 @@ gint scroll_event( GtkWidget *widget, GdkEventScroll *event, gpointer d )
   mouse_x = x = (int) event->x;
   mouse_y = y = (int) event->y;
 
-  if( !(x % ws_width) || !(y % ws_height) ) /* WS border */
-    return TRUE;
+  if( !(x % ws_width) || !(y % ws_height) ) { /* WS border */
+    if( x == width - 1 )
+      x--;
+    if( y == height - 1 )
+      y--;
+  }
 
   /* Button4 is for selecting the previous workspace */
   if( event->direction == GDK_SCROLL_UP ) {


### PR DESCRIPTION
When the pager is pinned against screen border(s), it is very annoying
when a mouse click is ignored because it occured on the first boundary
pixel line.

Now, all workspaces borders are clickable, the bottom and right ones
too. In these cases, a click on the workspace respectively above or at
left is "emulated".
